### PR TITLE
Fix `char signedness` problem with var `virname`

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,6 @@
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::ffi::c_char;
 use std::ptr;
 use std::str;
 use std::mem;
@@ -78,7 +79,7 @@ pub struct Engine {
 unsafe impl Send for Engine {}
 unsafe impl Sync for Engine {}
 
-fn map_scan_result(result: cl_error_t, virname: *const i8) -> Result<ScanResult, ClamError> {
+fn map_scan_result(result: cl_error_t, virname: *const c_char) -> Result<ScanResult, ClamError> {
     match result {
         cl_error_t::CL_CLEAN => Ok(ScanResult::Clean),
         cl_error_t::CL_BREAK => Ok(ScanResult::Whitelisted),
@@ -231,7 +232,7 @@ impl Engine {
     pub fn scan_file(&self, path: &str, settings: &mut ScanSettings) -> Result<ScanResult, ClamError> {
         let raw_path = CString::new(path).unwrap();
         unsafe {
-            let mut virname: *const i8 = ptr::null();
+            let mut virname: *const c_char = ptr::null();
             let result = clamav_sys::cl_scanfile(
                 raw_path.as_ptr(),
                 &mut virname,
@@ -249,7 +250,7 @@ impl Engine {
     /// loaded and compiled.
     pub fn scan_descriptor(&self, descriptor: i32, settings: &mut ScanSettings, filename: Option< &str >) -> Result<ScanResult, ClamError> {
         unsafe {
-            let mut virname: *const i8 = ptr::null();
+            let mut virname: *const c_char = ptr::null();
             let filename_cstr = filename.map(|x| CString::new(x).expect("CString::new failed"));
             let mut scanned : c_ulong = 0;
             let result = clamav_sys::cl_scandesc(
@@ -283,7 +284,7 @@ impl Engine {
     /// @param engine        The scanning engine.
     /// @param scanoptions   The scanning options.
     pub fn scan_map(&self, map : & Fmap, filename: Option<&str>, settings: &mut ScanSettings) -> Result<ScanResult, ClamError> {
-        let mut virname: *const i8 = ptr::null();
+        let mut virname: *const c_char = ptr::null();
         let c_filename = filename.map(|n| CString::new(n).expect("CString::new failed"));
         let result = unsafe {
             clamav_sys::cl_scanmap_callback(


### PR DESCRIPTION
`CStr::from_ptr` need a `c_char` type argument, which may be of `signed` or `unsigned`(type `u8` or `i8` in rust), depending on architecture, causing `type mismatch` error on architecture such as `riscv64`.

Changing the type of `virname` from `i8` to `c_char` fixes this.